### PR TITLE
BlogOpen uses VIMPRESS env variable

### DIFF
--- a/plugin/vimrepress.py
+++ b/plugin/vimrepress.py
@@ -896,9 +896,8 @@ def blog_guess_open(what):
     blog_index = -1
     if type(what) is str:
 
-        for i, p in enumerate(vim.eval("VIMPRESS")):
-            if what.startswith(p["blog_url"]):
-                blog_index = i
+        if what.startswith(g_data.blog_url):
+            blog_index = 1
 
         # User input a url contained in the profiles
         if blog_index != -1:


### PR DESCRIPTION
BlogOpen failed because it was trying to use VIMPRESS. Instead, use `blog_url`
as everywhere else.
